### PR TITLE
github no longer supports legacy git protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Openwrt Build Procedure
 This is a standard OpenWrt Feed, therefore packages should be built in the same way as another OpenWrt package.
 
-1. Add to feeds.conf: `src-git pyther git://github.com/pyther/openwrt-feed`
+1. Add to feeds.conf: `src-git pyther https://github.com/pyther/openwrt-feed.git`
 2. Update the feed: `./scripts/feeds update pyther`
 3. Install the package: `./scritps/feeds install $PKGNAME`
 4. Build Package: `make package/$PKGNAME/{download,prepare,compile}' 

--- a/net/goeap_proxy/Makefile
+++ b/net/goeap_proxy/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=goeap_proxy
-PKG_VERSION:=0.2.0
+PKG_VERSION:=0.3.0
 PKG_RELEASE:=1
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/pyther/goeap_proxy.git
-PKG_SOURCE_VERSION:=12ebcc82b92fd69083e5b3ffde9050e93a20d17a
+PKG_SOURCE_VERSION:=3abd66cf35c70b86fe75989ca64c7a72cc8fa797
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1

--- a/net/goeap_proxy/files/etc/init.d/goeap_proxy
+++ b/net/goeap_proxy/files/etc/init.d/goeap_proxy
@@ -31,8 +31,8 @@ start_service()
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_set_param command $PROG
-    procd_append_param command "${if_wan}"
-    procd_append_param command "${if_router}"
+    procd_append_param command -if-wan "${if_wan}"
+    procd_append_param command -if-router "${if_router}"
     if [ $ignore_logoff != "0" ]; then
         procd_append_param command -ignore-logoff
     fi

--- a/net/goeap_proxy/files/etc/init.d/goeap_proxy
+++ b/net/goeap_proxy/files/etc/init.d/goeap_proxy
@@ -31,8 +31,8 @@ start_service()
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_set_param command $PROG
-    procd_append_param command -if-wan "${if_wan}"
-    procd_append_param command -if-router "${if_router}"
+    procd_append_param command "${if_wan}"
+    procd_append_param command "${if_router}"
     if [ $ignore_logoff != "0" ]; then
         procd_append_param command -ignore-logoff
     fi


### PR DESCRIPTION
error message:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.