### PR TITLE
Updates to github and goeap_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Openwrt Build Procedure
 This is a standard OpenWrt Feed, therefore packages should be built in the same way as another OpenWrt package.
 
-1. Add to feeds.conf: `src-git pyther git://github.com/pyther/openwrt-feed`
+1. Add to feeds.conf: `src-git pyther https://github.com/pyther/openwrt-feed`
 2. Update the feed: `./scripts/feeds update pyther`
 3. Install the package: `./scritps/feeds install $PKGNAME`
 4. Build Package: `make package/$PKGNAME/{download,prepare,compile}' 

--- a/net/goeap_proxy/Makefile
+++ b/net/goeap_proxy/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=goeap_proxy
-PKG_VERSION:=0.2.0
+PKG_VERSION:=0.3.0
 PKG_RELEASE:=1
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/pyther/goeap_proxy.git
-PKG_SOURCE_VERSION:=12ebcc82b92fd69083e5b3ffde9050e93a20d17a
+PKG_SOURCE_VERSION:=3abd66cf35c70b86fe75989ca64c7a72cc8fa797
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
1) Github has changed the connection security hence the need for secure protocol to the project's url.

2) Updated the Makefile to pull the latest version of goeap_proxy.

Sign-off Gabriel Rodriguez