### PR TITLE
Numerous fixes for goeap_proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,25 @@
 FROM alpine:latest
+
+# Required for goeap-tools
+# Build dependency: Please install GNU 'tar'
+# Build dependency: Please install GNU 'find'
+# Build dependency: Please install 'xargs' that supports '-r/--no-run-if-empty'
+# Build dependency: Please install GNU diffutils
+# Build dependency: Please install GNU 'grep'
+# Build dependency: Please install GNU 'grep'
+# Build dependency: Please install 'gzip'
+# Build dependency: Please install 'unzip'
+# Build dependency: Please install GNU 'wget'
+# Build dependency: Please install GNU 'install'
+# Build dependency: Missing argp.h Please install the argp-standalone package if musl libc
+# Build dependency: Missing fts.h Please install the musl-fts-dev package if musl libc
+# Build dependency: Missing obstack.h Please install the musl-obstack-dev package if musl libc
+# Build dependency: Missing libintl.h Please install the musl-libintl package if musl libc
+
 RUN apk update && \
+    apk add tar findutils diffutils grep gzip unzip wget coreutils argp-standalone musl-fts-dev musl-obstack-dev musl-libintl && \
     apk add build-base && \
-    apk add bash bzip2 gawk git && \
+    apk add bash bzip2 xz gawk git && \
     apk add perl rsync && \
     apk add ncurses-dev && \
     apk add python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ RUN apk update && \
     apk add bash bzip2 gawk git && \
     apk add perl rsync && \
     apk add ncurses-dev && \
-    apk add python2 python3
-RUN addgroup -g 1000 app && \
-    adduser -D -G app -s /sbin/nologin -u 1000 app
-USER app
+    apk add python3
 
-ENTRYPOINT ["/bin/sh", "/src/entry.sh"]
+WORKDIR /src
+
+ENTRYPOINT ["/bin/sh", "entry.sh"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Openwrt Build Procedure
 This is a standard OpenWrt Feed, therefore packages should be built in the same way as another OpenWrt package.
 
-1. Add to feeds.conf: `src-git pyther git://github.com/pyther/openwrt-feed`
+1. Add to feeds.conf: `src-git pyther https://github.com/pyther/openwrt-feed.git`
 2. Update the feed: `./scripts/feeds update pyther`
 3. Install the package: `./scritps/feeds install $PKGNAME`
 4. Build Package: `make package/$PKGNAME/{download,prepare,compile}' 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # OpenWrt Feed
+
+Build `goeap_proxy` or other projects for a specific install on OpenWRT.
+
+
 ## Packages
 
 * [`goeap_proxy`](https://github.com/pyther/goeap_proxy) (Go: Proxy EAP packets between network interfaces)
@@ -6,8 +10,49 @@
 * [`ookla-speedtest`](https://www.speedtest.net/apps/cli) (Ookla's Speedtest CLI)
 
 ## Building Packages
+
+### With Podman and Buildah
+
+Most people will want this method, for simplicity. Just install `buildah` and
+`podman` on your distribution. Everything else will run rootless. The included
+DockerFile should make the build process simple and remove any enivorment
+specific build issues.
+
+1. Clone: `git clone https://github.com/pyther/openwrt-feed.git`
+2. Change Dir: `cd openwrt-feed`
+3. Update `SDK_URL`, and `SDK_SUM` in `entry.sh`, you can get these paths by going to the
+	* [OpenWRT Release page](https://downloads.openwrt.org/releases), select the
+		one you want, likely the newest at the bottom. **It must match the version
+		on your router.**
+	* Select your build.
+	* Select your chipset.
+	* Scroll down to "Supplementary Files": the link under "Filename" is your `SDK_URL`; the "sha256sum" is your `SDK_SUM`.
+4. Build image, note the image created won't actually have the SDK in it. Just the environment to put the SDK.
+	```shell
+	buildah bud -t openwrt-sdk:latest .
+	```
+5. Download the SDK and build package: replace `goeap_proxy` with the name of the package you want to build
+	```shell
+	podman run --rm -it -v "${PWD}:/src" openwrt-sdk:latest goeap_proxy
+	```
+6. Built packages can be found in `./build/*/bin/packages/*/pyther`, or with `find`,
+	```shell
+	# See what packages were built
+	ls ./build/*/bin/packages/*/pyther
+
+	# Find them by their full path
+	find . -name '*.ipk' -path '*/pyther/*'
+	```
+7. After you have the packages built you can either,
+	* Upload and install directly to LuCI (web interface)
+	  * Log into LuCI
+		* Click on "System" tab, select "Software" from the drop down
+		* Click "Upload Package"
+	* Copy the package to the router and install on the CLI with `opkg install ./package.ipk`
+
 ### Openwrt Build Procedure
-This is a standard OpenWrt Feed, therefore packages should be built in the same way as another OpenWrt package.
+
+While more complex, this is a standard OpenWrt Feed, therefore packages can be built in the same way as another OpenWrt package.
 
 1. Add to feeds.conf: `src-git pyther https://github.com/pyther/openwrt-feed.git`
 2. Update the feed: `./scripts/feeds update pyther`
@@ -18,66 +63,3 @@ Resources
 - https://openwrt.org/docs/guide-developer/using_the_sdk
 - https://openwrt.org/docs/guide-developer/single.package
 - https://openwrt.org/docs/guide-developer/quickstart-build-images
-
-### With Docker
-The included DockerFile should make the build process simple and remove any enivorment specific build issues.
-
-1. Clone: `git clone https://github.com/pyther/openwrt-feed.git`
-2. Change Dir: `cd openwrt-feed`
-3. Update `SDK_URL`, and `SDK_SUM` in `entry.sh`
-4. Update UID/GID in the Dockerfile to match that of your current user (`id`)
-4. Build Docker Image: `sudo docker build . -t openwrt-sdk:latest`
-5. Create Build Directory: `mkdir ./build`
-6. Build Package: `sudo docker run --rm -it --volume $(pwd):/src openwrt-sdk:latest goeap_proxy`
-  - replace `goeap_proxy` with the name of the package you want to build
-7. Built packages can be found in `./build/openwrt-sdk-x86-64_gcc-8.4.0_musl.Linux-x86_64/bin/packages/x86_64/pyther`
-
-Troubleshooting
-
-To get an interactive shell in container to troubleshoot build problems run
-```
-$ sudo docker run -it --volume $(pwd):/src --entrypoint /bin/sh openwrt-sdk:latest
-$ sh -x /tmp/entry.sh # no args setups the build envirnoment
-$ sh -x /tmp/entry.sh goeap_proxy # builds goeap_proxy package
-```
-
-
-### With Helper Script
-The included entry.sh will automate the process of downloading, extracting, and
-building the package. You can either run the script or use it as guide for
-manual command execution.
-
-1. Clone: `git clone https://github.com/pyther/openwrt-feed.git`
-2. Change Dir: `cd openwrt-feed`
-3. Update 'BUILD_DIR`, `SDK_URL`, and `SDK_SUM` in `entry.sh`
-4. sh entry.sh PKG_NAME
-
-## Building OpenWrt Image
-
-1. Download the OpenWrt Image Builder: [Instructions: Using the Image Builder](https://openwrt.org/docs/guide-user/additional-software/imagebuilder)
-    ```
-    $ wget https://downloads.openwrt.org/releases/18.06.4/targets/x86/64/openwrt-imagebuilder-18.06.4-x86-64.Linux-x86_64.tar.xz
-    ```
-
-2. Extract Image Builder and enter directory
-    ```
-    $ tar xf openwrt-imagebuilder-18.06.4-x86-64.Linux-x86_64.tar.xz
-    $ cd openwrt-imagebuilder-18.06.4-x86-64.Linux-x86_64
-    ```
-
-3. Copy built package into `./packages`
-    ```
-    $ cp ~/build/openwrt-sdk-18.06.4-x86-64_gcc-7.3.0_musl.Linux-x86_64/bin/packages/x86_64/pyther/goeap_proxy_0.200502.3-1_x86_64.ipk ./packages
-    ```
-
-4. Build Image
-    ```
-    $ make image PACKAGES="goeap_proxy"
-    ```
-
-    Note: other platforms (non-x86) you mant to to specify `PROFILE=XXX`
-
-    List of profiles can be obtained with
-    ```
-    $ make info
-    ```

--- a/docs/goeap_configuration.md
+++ b/docs/goeap_configuration.md
@@ -1,0 +1,63 @@
+`goeap_proxy` Configuration
+====
+
+For an example of configuration of `goeap_proxy`, this works on WRT1900. This
+will allow you to connect to an ONT directly by forwarding EAP to an unrooted
+(or rooted) network provided gateway.
+
+`/etc/config/network`
+----
+
+Here is an example of the relevant parts of `/etc/config/network`
+
+```text
+config interface 'lan'
+	option device 'br-lan'
+	option proto 'static'
+	option ipaddr '192.168.1.1'
+	option netmask '255.255.255.0'
+	option ip6assign '60'
+
+config device
+	option name 'wan'
+	option macaddr 'YOUR_ONT_MAC'
+
+config interface 'wan'
+	option device 'wan'
+	option force_link '1'
+	option proto 'dhcp'
+	option peerdns '0'
+	list dns '1.1.1.1'
+	list dns '1.0.0.1'
+
+config interface 'ont'
+	option proto 'none'
+	option device 'wan'
+
+config interface 'rgw'
+	option proto 'none'
+	option device 'lan1'
+
+config interface 'wan6'
+	option device 'wan'
+	option proto 'dhcpv6'
+```
+
+`/etc/config/goeap_proxy`
+
+----
+And this matches with this part of `/etc/config/goeap_proxy`
+
+```text
+config goeap_proxy 'global'
+	option wan 'ont'
+	option router 'rgw'
+	option ignore_logoff 0
+```
+
+After updating both of these files run
+
+```shell
+/etc/init.d/network restart
+/etc/init.d/goeap_proxy restart
+```

--- a/entry.sh
+++ b/entry.sh
@@ -2,16 +2,10 @@
 BUILD_DIR='build'
 mkdir "$BUILD_DIR"
 
-# UPDATE ME! x86_64 snapshot
-# Platform List: https://openwrt.org/docs/platforms/start
-# Release Page: https://downloads.openwrt.org/releases/19.07.3/targets/
-SDK_URL="https://downloads.openwrt.org/snapshots/targets/x86/64/openwrt-sdk-x86-64_gcc-8.4.0_musl.Linux-x86_64.tar.xz"
-SDK_SUM="6a70cd1e6249125b0c669679fba9302e40cffae004f63b3a5117b2fff6d42049"
-
-#SDK_URL="https://downloads.openwrt.org/releases/19.07.3/targets/x86/64/openwrt-sdk-19.07.3-x86-64_gcc-7.5.0_musl.Linux-x86_64.tar.xz"
-#SDK_SUM="aeafd4f8405ac2a226c3aa1b5b98e1994a541cdca2f2fe2d0b8a1696a73cf8d9"
-#SDK_URL="https://downloads.openwrt.org/releases/19.07.3/targets/brcm2708/bcm2710/openwrt-sdk-19.07.3-brcm2708-bcm2710_gcc-7.5.0_musl.Linux-x86_64.tar.xz"
-#SDK_SUM="31edcbb9a1a9500040d1baef84cea639561d97ed2a9808bef2b109014755c813"
+# UPDATE ME! x86_64 release
+# Release Page: https://downloads.openwrt.org/releases/
+SDK_URL=https://archive.openwrt.org/releases/22.03.2/targets/x86/64/openwrt-sdk-22.03.2-x86-64_gcc-11.2.0_musl.Linux-x86_64.tar.xz
+SDK_SUM=d5718b743004f6b16996c439f35833c89e1a38b056c599b2917f22b24dc467f8
 
 SDK_FILE=$(basename $SDK_URL)
 

--- a/entry.sh
+++ b/entry.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
+
+# Can also be set to archive
+SERVER="downloads"
 BUILD_DIR='build'
+VERSION="23.05.2"
+ARCH="x86"
+PLATFORM="64"
+COMPILER="gcc-12.3.0_musl"
 mkdir "$BUILD_DIR"
 
 # UPDATE ME! x86_64 release
 # Release Page: https://downloads.openwrt.org/releases/
-SDK_URL=https://archive.openwrt.org/releases/22.03.2/targets/x86/64/openwrt-sdk-22.03.2-x86-64_gcc-11.2.0_musl.Linux-x86_64.tar.xz
-SDK_SUM=d5718b743004f6b16996c439f35833c89e1a38b056c599b2917f22b24dc467f8
-
+SDK_URL="https://${SERVER}.openwrt.org/releases/${VERSION}/targets/${ARCH}/${PLATFORM}/openwrt-sdk-${VERSION}-${ARCH}-${PLATFORM}_${COMPILER}.Linux-x86_64.tar.xz"
+SDK_SUM=df9cbce6054e6bd46fcf28e2ddd53c728ceef6cb27d1d7fc54a228f272c945b0
 SDK_FILE=$(basename $SDK_URL)
 
 download() {
@@ -19,7 +25,7 @@ setup() {
     [ -f $SDK_FILE ] || download
 
     # check that download tar matches expected checksum
-    if [ "$(sha256sum $SDK_FILE | awk '{print $1}')" != $SDK_SUM ]; then
+    if [ -n "$SDK_SUM" && "$(sha256sum $SDK_FILE | awk '{print $1}')" != "$SDK_SUM" ]; then
        echo "$SDK_FILE does not match sha256 signature"
        exit 1
     fi

--- a/entry.sh
+++ b/entry.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-BUILD_DIR='/src/build'
+BUILD_DIR='build'
+mkdir "$BUILD_DIR"
 
 # UPDATE ME! x86_64 snapshot
 # Platform List: https://openwrt.org/docs/platforms/start

--- a/net/goeap_proxy/Makefile
+++ b/net/goeap_proxy/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=goeap_proxy
-PKG_VERSION:=0.2.0
+PKG_VERSION:=0.3.0
 PKG_RELEASE:=1
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/pyther/goeap_proxy.git
-PKG_SOURCE_VERSION:=12ebcc82b92fd69083e5b3ffde9050e93a20d17a
+PKG_SOURCE_VERSION:=3abd66cf35c70b86fe75989ca64c7a72cc8fa797
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1

--- a/net/goeap_proxy/Makefile
+++ b/net/goeap_proxy/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=goeap_proxy
-PKG_VERSION:=0.3.0
+PKG_VERSION:=0.3.1
 PKG_RELEASE:=1
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/pyther/goeap_proxy.git

--- a/net/goeap_proxy/files/etc/init.d/goeap_proxy
+++ b/net/goeap_proxy/files/etc/init.d/goeap_proxy
@@ -22,20 +22,22 @@ start_service()
     config_get router global router
     config_get_bool ignore_logoff global 'ignore_logoff' '0'
 
-    local if_wan=$(uci get "network.${wan}.ifname")
-    local if_router=$(uci get "network.${router}.ifname")
+    fatal=0
+    local if_wan=$(uci get "network.${wan}.device" 2>/dev/null)
+    if [ "$?" != 0 ]; then echo "ERROR goeap_proxy is looking for $wan but it is not configured currently" >&2; fatal=1; fi
+    local if_router=$(uci get "network.${router}.device" 2>/dev/null)
+    if [ "$?" != 0 ]; then echo "ERROR goeap_proxy is looking for $router but it is not configured currently" >&2; fatal=1; fi
+    if [ "$fatal" != 0 ]; then echo "Can not proceed to start goeap_proxy" >&2; exit 1; fi;
 
     procd_open_instance
-    # attempt to restart every 30 seconds, the eap proxy for internet connectivity
-    procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-30} ${respawn_retry:-0}
-    procd_set_param stdout 1
-    procd_set_param stderr 1
-    procd_set_param command $PROG
-    procd_append_param command "${if_wan}"
-    procd_append_param command "${if_router}"
-    if [ $ignore_logoff != "0" ]; then
-        procd_append_param command -ignore-logoff
-    fi
+      # attempt to restart every 30 seconds, the eap proxy for internet connectivity
+      procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-30} ${respawn_retry:-0}
+      procd_set_param stdout 1
+      procd_set_param stderr 1
+      procd_set_param command "$PROG" "${if_wan}" "${if_router}"
+      if [ $ignore_logoff != "0" ]; then
+          procd_append_param command -ignore-logoff
+      fi
     procd_close_instance
 }
 
@@ -43,4 +45,3 @@ service_triggers()
 {
     procd_add_reload_trigger "goeap_proxy" "network"
 }
-


### PR DESCRIPTION
This takes in a change from @ddrown

This also

* updates the version goeap_proxy.
* adds **lots** of documentation.
* moves from docker to buildah/podman which work rootless.
* updates init.d scripts to be more verbose when they fail
* implements changes in OpenWRT 22 which drops `ifname`