### PR TITLE
Updates for compatibility with newer OpenWrt versions.

### DIFF
--- a/net/goeap_proxy/files/etc/init.d/goeap_proxy
+++ b/net/goeap_proxy/files/etc/init.d/goeap_proxy
@@ -22,8 +22,8 @@ start_service()
     config_get router global router
     config_get_bool ignore_logoff global 'ignore_logoff' '0'
 
-    local if_wan=$(uci get "network.${wan}.ifname")
-    local if_router=$(uci get "network.${router}.ifname")
+    local if_wan=$(uci get "network.${wan}.device")
+    local if_router=$(uci get "network.${router}.device")
 
     procd_open_instance
     # attempt to restart every 30 seconds, the eap proxy for internet connectivity
@@ -31,8 +31,8 @@ start_service()
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_set_param command $PROG
-    procd_append_param command "${if_wan}"
-    procd_append_param command "${if_router}"
+    procd_append_param command "-if-wan" "${if_wan}"
+    procd_append_param command "-if-router" "${if_router}"
     if [ $ignore_logoff != "0" ]; then
         procd_append_param command -ignore-logoff
     fi


### PR DESCRIPTION
Update 1:
The `ifname` property of a network appears to be hit or miss. The `device` property is consistent now in uci network output.

Update 2:
On `OpenWrt SNAPSHOT r24673-659f027e69`, this service failed to start due to the following error:

```sh
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]: flag provided but not defined: -if-wan eth0
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]: Usage of /usr/bin/goeap_proxy:
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:   -if-router string
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:     	interface of the AT&T Router
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:   -if-wan string
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:     	interface of the AT&T ONT/WAN
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:   -ignore-logoff
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:     	ignore EAPOL-Logoff packets
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:   -promiscuous
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:     	place interfaces into promiscuous mode instead of multicast
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:   -version
Mon Dec 18 11:18:39 2023 daemon.err goeap_proxy[2017]:     	display version
```

Appending the explicit `-if-wan` and `-if-router` args to the procd command corrects the above error.