### PR TITLE
Bump the feeds repo to point to goeap_proxy rev 0.3.0

### DIFF
--- a/net/goeap_proxy/Makefile
+++ b/net/goeap_proxy/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=goeap_proxy
-PKG_VERSION:=0.2.0
+PKG_VERSION:=0.3.0
 PKG_RELEASE:=1
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/pyther/goeap_proxy.git
-PKG_SOURCE_VERSION:=12ebcc82b92fd69083e5b3ffde9050e93a20d17a
+PKG_SOURCE_VERSION:=3abd66cf35c70b86fe75989ca64c7a72cc8fa797
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
The shell script in this repo is using the format of rev 0.3.0 of `goeap_proxy`'s, but the makefile is building the rev 0.2.0 of `goeap_proxy`. 

Since `goeap_proxy` had its input format changed between 0.3.0 and 0.2.0, this mismatch would break the functionality.
